### PR TITLE
Add NoFail setting to continue installation on fail

### DIFF
--- a/apt.conf.d/intoto
+++ b/apt.conf.d/intoto
@@ -9,4 +9,10 @@ APT::Intoto {
   Keyids {
     "88876A89E3D4698F83D3DB0E72E33CA3E0E04E46"
   };
+  // If set to "true" apt installation will continue even if in-toto
+  // verification fails, but only if it fails because of missing link
+  // metadata.
+  // This is meant for a slow rollout, as soon as there is broad support for
+  // rebuilt debian packages, this option should not be used.
+  NoFail {"true"}
 };

--- a/tests/data/intoto.conf.docker
+++ b/tests/data/intoto.conf.docker
@@ -8,4 +8,5 @@ APT::Intoto {
   Keyids {
     "88876A89E3D4698F83D3DB0E72E33CA3E0E04E46"
   };
+  NoFail {"true"}
 };


### PR DESCRIPTION
**Fixes issue #**:
Closes #12 

**Description of the changes being introduced by the pull request**:
If set to "true" `NoFail` allows a client to install packages even if in-toto verification fails, but only if the fail reason is missing link metadata.

This setting should be removed, once there is broader support for rebuilder in-toto link metadata.

This PR also configures the online demo (see Dockerfile) to enable the `NoFail` setting.

Tests and documentation will be added with #9 and #14.


**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


