### PR TITLE
Prepare downstream debian release 0.1.1-3

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+apt-transport-in-toto (0.1.1-3) unstable; urgency=medium
+
+  * Bump standards version
+  * Fix debian/watch
+
+ -- Lukas Puehringer <lukas.puehringer@nyu.edu>  Thu, 02 Feb 2023 09:36:09 +0100
+
 apt-transport-in-toto (0.1.1-2) unstable; urgency=medium
 
   * Source upload for testing migration.

--- a/debian/control
+++ b/debian/control
@@ -19,7 +19,7 @@ Build-Depends:
  python3-coverage,
  in-toto (>= 1.0.0),
  gnupg2,
-Standards-Version: 4.5.1
+Standards-Version: 4.6.2
 Rules-Requires-Root: no
 Homepage: https://in-toto.io
 Vcs-Git: https://github.com/in-toto/apt-transport-in-toto.git -b debian

--- a/debian/watch
+++ b/debian/watch
@@ -1,3 +1,6 @@
 version=4
-opts=pgpsigurlmangle=s/archive\/v?(\d\S+)\.tar\.gz/releases\/download\/v$1\/v$1\.tar\.gz\.asc/ \
-  https://github.com/in-toto/apt-transport-in-toto/releases/latest .*/v?(\d\S+)\.tar\.gz
+opts="searchmode=plain,\
+pgpsigurlmangle=s~api.github.com/repos/([^/]+)/([^/]+)/tarball/v(@ANY_VERSION@)~github.com/$1/$2/releases/download/v$3/v$3.tar.gz.asc~,\
+filenamemangle=s%v?@ANY_VERSION@%@PACKAGE@-$1.tar.xz%" \
+https://api.github.com/repos/in-toto/apt-transport-in-toto/releases?per_page=50 \
+https://api.github.com/repos/[^/]+/[^/]+/tarball/v?@ANY_VERSION@


### PR DESCRIPTION
currently on https://mentors.debian.net/package/apt-transport-in-toto/, let's merge when released
